### PR TITLE
fix: melhora visibilidade e estilo do seletor de idioma

### DIFF
--- a/src/lib/i18n/LanguageSelector.tsx
+++ b/src/lib/i18n/LanguageSelector.tsx
@@ -8,20 +8,27 @@ export function LanguageSelector() {
   const { language, setLanguage } = useLanguage();
 
   return (
-    <div className="relative inline-flex items-center gap-2 bg-white/10 backdrop-blur-sm rounded-lg px-3 py-2 border border-white/20">
-      <Globe className="w-4 h-4 text-blue-200" />
-      <select
-        value={language}
-        onChange={(e) => setLanguage(e.target.value as Language)}
-        className="bg-transparent text-white text-sm cursor-pointer outline-none appearance-none pr-6"
-      >
-        <option value="en" className="bg-slate-800 text-white">English</option>
-        <option value="pt" className="bg-slate-800 text-white">Português</option>
-      </select>
-      <div className="absolute right-2 top-1/2 transform -translate-y-1/2 pointer-events-none">
-        <svg className="w-3 h-3 text-blue-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
+    <div className="relative group">
+      <div className="aura-glass rounded-2xl px-4 py-2.5 flex items-center gap-3
+                      border border-white/10 hover:border-[#FFA850]/30
+                      transition-all duration-300 hover:shadow-lg hover:shadow-[#FFA850]/10">
+        <Globe className="w-5 h-5 text-[#FFA850] transition-transform duration-300 group-hover:rotate-12" />
+        <select
+          value={language}
+          onChange={(e) => setLanguage(e.target.value as Language)}
+          className="bg-transparent text-gray font-medium text-sm cursor-pointer
+                     outline-none appearance-none pr-8
+                     hover:text-[#FFA850] transition-colors duration-300"
+        >
+          <option value="en" className="bg-gray-900 text-gray py-2">English</option>
+          <option value="pt" className="bg-gray-900 text-gray py-2">Português</option>
+        </select>
+        <div className="absolute right-3 top-1/2 transform -translate-y-1/2 pointer-events-none">
+          <svg className="w-4 h-4 text-[#FFA850] transition-transform duration-300 group-hover:translate-y-0.5"
+               fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Aplica estilo glassmorphism com classe aura-glass
- Aumenta contraste com fundo escuro e bordas mais visíveis
- Adiciona animações hover suaves e usa cor coral (#FFA850) da identidade visual Aura

## Test plan
- [x] Verificar que o seletor de idioma está visível em todas as páginas
- [x] Testar funcionalidade de troca de idioma
- [x] Confirmar que as animações hover funcionam corretamente

🤖 Generated with [Claude Code](https://claude.ai/code)